### PR TITLE
Fallback fix

### DIFF
--- a/pages/api/revalidate.ts
+++ b/pages/api/revalidate.ts
@@ -50,10 +50,15 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 			});
 		}
 
-		const revalidationUrl = `/${typeTranslation[type]}/${slug.current}`;
-		console.log('Revalidating', revalidationUrl);
+		const resourceUrl = `/${typeTranslation[type]}/${slug.current}`;
+		const summaryUrl = `/${typeTranslation[type]}`;
+		const homeUrl = `/`;
 
-		await res.revalidate(revalidationUrl);
+		console.log('Revalidating', revalidationUrl);
+		await res.revalidate(resourceUrl);
+		await res.revalidate(summaryUrl);
+		await res.revalidate(homeUrl);
+
 		return res.json({
 			message: 'Successfully revalidated!',
 			revalidated: true,

--- a/pages/api/revalidate.ts
+++ b/pages/api/revalidate.ts
@@ -54,7 +54,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 		const summaryUrl = `/${typeTranslation[type]}`;
 		const homeUrl = `/`;
 
-		console.log('Revalidating', revalidationUrl);
+		console.log('Revalidating', resourceUrl);
 		await res.revalidate(resourceUrl);
 		await res.revalidate(summaryUrl);
 		await res.revalidate(homeUrl);

--- a/pages/blog/[post].tsx
+++ b/pages/blog/[post].tsx
@@ -67,7 +67,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: false,
+    fallback: 'blocking',
   };
 };
 

--- a/pages/portfolio/[project].tsx
+++ b/pages/portfolio/[project].tsx
@@ -75,7 +75,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: false,
+    fallback: 'blocking',
   };
 };
 

--- a/pages/technology/[technology].tsx
+++ b/pages/technology/[technology].tsx
@@ -82,7 +82,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: false,
+    fallback: 'blocking',
   };
 };
 


### PR DESCRIPTION
Configure fallback for resource pages to be 'blocking' to ensure that new pages will generate a new static path.
Reconfigured revalidation endpoint to also revalidate summary pages and home page.